### PR TITLE
Document high radio power bit in BLE specifications

### DIFF
--- a/booster_ble_specification.rst
+++ b/booster_ble_specification.rst
@@ -1,0 +1,110 @@
+***************************************
+Booster Bluetooth Low Energy (BLE) Spec
+***************************************
+
+:status: DRAFT
+
+This document describes how Combustion Inc. Boosters send and receive
+data over BLE.
+
+Booster is a Repeater Node, and also has additional functionality. This
+means it conforms to the MeatNet Node BLE Specification in:
+
+Sphinx link:
+:doc:`/meatnet_node_ble_specification`.
+
+GitHub link:
+`MeatNet Node BLE Specification <./meatnet_node_ble_specification.rst>`_
+
+This document details additional features and differences specific to the Booster
+beyond what's included in the MeatNet Node BLE Specification.
+
+.. contents:: Table of Contents
+
+Advertising
+###########
+
+The Booster interleaves Booster-specific advertisements between MeatNet Node advertisements.
+MeatNet Node advertisements contain the repeated data for probes. Booster advertisements
+include information specific to this device.
+
+For the base MeatNet Node advertising format, see:
+
+Sphinx link:
+:doc:`/meatnet_node_ble_specification#advertising`.
+
+GitHub link:
+`MeatNet Node BLE Specification <./meatnet_node_ble_specification.rst#advertising>`_
+
+Booster Device Info
+-------------------
+
+When advertising its own device info, the Booster uses the following format:
+
+.. _bluetooth company ids: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+
+=================================== ===== ==========================================
+Field                               Bytes Value
+=================================== ===== ==========================================
+Vendor ID                           2     ``0x09C7`` (see `Bluetooth company IDs`_)
+Product Type                        1     ``0x05`` (Booster)
+Serial Number                       10    Node serial number
+Reserved                            11    Reserved
+Booster Preferences                 1     See `Booster Preferences`_.
+=================================== ===== ==========================================
+
+
+GATT Services and Characteristics
+#################################
+
+Sphinx link:
+:ref:`See MeatNet Node GATT Services and Characteristics <node_gatt_services_and_characteristics>`
+
+GitHub link:
+`See MeatNet Node GATT Services and Characteristics <./meatnet_node_ble_specification.rst#gatt-services-and-characteristics>`_
+
+
+UART Messages
+#############
+
+Booster is a MeatNet repeater Node and supports all messages in:
+
+Sphinx link:
+:ref:`MeatNet Node UART Messages <node_uart_messages>`.
+
+GitHub link:
+`MeatNet Node UART Messages <./meatnet_node_ble_specification.rst#uart-messages>`_
+
+
+Common Data Formats
+###################
+
+This document defines several data formats that are common between advertising
+data and characteristic data.
+
+Booster Preferences
+-------------------
+
+Booster preferences are expressed in a packed 8-bit (1-byte) field:
+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1    | `High Radio Power`_       |
++------+---------------------------+
+| 2-8  | Reserved                  |
++------+---------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether
+the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 1   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+

--- a/booster_ble_specification.rst
+++ b/booster_ble_specification.rst
@@ -49,8 +49,8 @@ Field                               Bytes Value
 Vendor ID                           2     ``0x09C7`` (see `Bluetooth company IDs`_)
 Product Type                        1     ``0x05`` (Booster)
 Serial Number                       10    Node serial number
-Reserved                            11    Reserved
 Booster Preferences                 1     See `Booster Preferences`_.
+Reserved                            11    Reserved
 =================================== ===== ==========================================
 
 

--- a/display_ble_specification.rst
+++ b/display_ble_specification.rst
@@ -49,8 +49,8 @@ Field                               Bytes Value
 Vendor ID                           2     ``0x09C7`` (see `Bluetooth company IDs`_)
 Product Type                        1     ``0x04`` (Display)
 Serial Number                       10    Node serial number
-Reserved                            11    Reserved
 Display Preferences                 1     See `Display Preferences`_.
+Reserved                            11    Reserved
 =================================== ===== ==========================================
 
 

--- a/display_ble_specification.rst
+++ b/display_ble_specification.rst
@@ -24,13 +24,34 @@ beyond what's included in the MeatNet Node BLE Specification.
 Advertising
 ###########
 
-The Display uses the base MeatNet Node advertising format as defined in:
+The Display interleaves Display-specific advertisements between MeatNet Node advertisements.
+MeatNet Node advertisements contain the repeated data for probes. Display advertisements
+include information specific to this device.
+
+For the base MeatNet Node advertising format, see:
 
 Sphinx link:
 :doc:`/meatnet_node_ble_specification#advertising`.
 
 GitHub link:
 `MeatNet Node BLE Specification <./meatnet_node_ble_specification.rst#advertising>`_
+
+Display Device Info
+-------------------
+
+When advertising its own device info, the Display uses the following format:
+
+.. _bluetooth company ids: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+
+=================================== ===== ==========================================
+Field                               Bytes Value
+=================================== ===== ==========================================
+Vendor ID                           2     ``0x09C7`` (see `Bluetooth company IDs`_)
+Product Type                        1     ``0x04`` (Display)
+Serial Number                       10    Node serial number
+Reserved                            11    Reserved
+Display Preferences                 1     See `Display Preferences`_.
+=================================== ===== ==========================================
 
 
 GATT Services and Characteristics
@@ -79,6 +100,33 @@ Common Data Formats
 
 This document defines several data formats that are common between advertising
 data and characteristic data.
+
+Display Preferences
+-------------------
+
+Display preferences are expressed in a packed 8-bit (1-byte) field:
+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1    | `High Radio Power`_       |
++------+---------------------------+
+| 2-8  | Reserved                  |
++------+---------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether
+the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 1   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+
 
 Timer Status
 ------------

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -60,6 +60,8 @@ Product Type                       1     See `Product Type`_ (Engine = ``6``)
 Serial Number                      10    Engine serial number (alphanumeric)
 Temperature Set Point              2     See `Temperature Point`_.
 Engine Status Flags                1     See `Engine Status Flags`_.
+Engine Preferences                 1     See `Engine Preferences`_.
+Reserved                           8     Reserved
 ================================== ===== =========================================
 
 
@@ -300,6 +302,33 @@ Bits       Description
 65-96      Fan on time in each time window (milliseconds)
 ========== =============================
 
+
+Engine Preferences
+------------------
+
+Engine preferences are expressed in a packed 8-bit (1-byte) field:
+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1    | `High Radio Power`_       |
++------+---------------------------+
+| 2-8  | Reserved                  |
++------+---------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether
+the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 1   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+
 
 Network Information
 -------------------

--- a/gauge_ble_specification.rst
+++ b/gauge_ble_specification.rst
@@ -62,8 +62,8 @@ Raw Temperature Data               2     See `Raw Temperature Data`_.
 Gauge Status Flags                 1     See `Gauge Status Flags`_.
 Reserved                           1     Reserved
 High-Low Alarm Status              4     See `High-Low Alarm Status`_.
-Reserved                           3     Reserved
 Gauge Preferences                  1     See `Gauge Preferences`_.
+Reserved                           3     Reserved
 ================================== ===== =========================================
 
 

--- a/gauge_ble_specification.rst
+++ b/gauge_ble_specification.rst
@@ -63,6 +63,7 @@ Gauge Status Flags                 1     See `Gauge Status Flags`_.
 Reserved                           1     Reserved
 High-Low Alarm Status              4     See `High-Low Alarm Status`_.
 Reserved                           3     Reserved
+Gauge Preferences                  1     See `Gauge Preferences`_.
 ================================== ===== =========================================
 
 
@@ -310,6 +311,33 @@ Alarm Temperature
 The alarm temperature is a packed 13-bit field that represents the alarm
 temperature in 0.1°C steps. It uses the same encoding as the 
 `Raw Temperature Data`_.
+
+Gauge Preferences
+-----------------
+
+Gauge preferences are expressed in a packed 8-bit (1-byte) field:
+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1    | `High Radio Power`_       |
++------+---------------------------+
+| 2-8  | Reserved                  |
++------+---------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether
+the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 1   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+
 
 Network Information
 -------------------

--- a/meatnet_node_ble_specification.rst
+++ b/meatnet_node_ble_specification.rst
@@ -1042,13 +1042,15 @@ Thermometer Preferences
 
 Thermometer preferences are expressed in a packed 8-bit (1-byte) field:
 
-+------+-------------------+
-| Bits | Description       |
-+======+===================+
-| 1-2  | See `Power Mode`_ |
-+------+-------------------+
-| 3-8  | Reserved          |
-+------+-------------------+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1-2  | See `Power Mode`_         |
++------+---------------------------+
+| 3    | See `High Radio Power`_   |
++------+---------------------------+
+| 4-8  | Reserved                  |
++------+---------------------------+
 
 Power Mode
 **********
@@ -1063,6 +1065,23 @@ Power Mode is expressed as a 2-bit enumerated field.
 ||     || * ``1``: Always On            |
 ||     || * ``2-3``: Reserved           |
 +------+--------------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 3   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+
+
+**Note:** MeatNet Node devices (Display, Booster, Gauge, Engine) transmit at high power (+8 dBm, bit=1) for improved range and MeatNet mesh reliability. When Nodes forward Probe status via MeatNet, they preserve the original Probe's high radio power bit value.
+
+**RSSI Adjustment:** When using RSSI for proximity detection or MeatNet association, applications should adjust thresholds based on this bit. High power devices (+8 dBm) will show approximately 8 dB higher (less negative) RSSI values at the same physical distance compared to normal power devices.
 
 Prediction Log
 ------------------------------

--- a/meatnet_node_ble_specification.rst
+++ b/meatnet_node_ble_specification.rst
@@ -56,8 +56,13 @@ The Node advertises the current state of all Combustion Inc. Probes connected
 to its network.
 
 It continually interleaves advertisements with the manufacturing data for
-each of the probes on the repeater network, cycling through them one-by-one
-with each advertisement.
+each of the probes on the repeater network, cycling through them one-by-one,
+along with device-specific advertisements for the Node itself.
+
+Repeated Probe Data
+*******************
+
+When advertising repeated Probe data, the Node uses the following format:
 
 ================================== ===== =========================================
 Field                              Bytes Value
@@ -71,7 +76,6 @@ Battery Status and Virtual Sensors 1     See `Battery Status and Virtual Sensors
 Network Information                1     See `Network Information`_.
 Overheating Sensors                1     Overheating sensors mask
 ================================== ===== =========================================
-
 
 .. _node_gatt_services_and_characteristics:
 
@@ -861,6 +865,7 @@ Possible values:
 * ``3``: Giant Grill Gauge
 * ``4``: Display (Timer)
 * ``5``: Booster (Charger)
+* ``6``: Engine
 
 Raw Temperature Data
 --------------------

--- a/probe_ble_specification.rst
+++ b/probe_ble_specification.rst
@@ -31,7 +31,7 @@ Legacy (BLE 4.0) Advertisement Packet
 ========================== ===== ==================================
 Field                      Bytes Value
 ========================== ===== ==================================
-Manufacturer Specific Data 24    See `Manufacturer Specific Data`_.
+Manufacturer Specific Data 25    See `Manufacturer Specific Data`_.
 ========================== ===== ==================================
 
 Legacy (BLE 4.0) Scan Response
@@ -59,6 +59,7 @@ Mode/ID                             1     See `Mode and ID Data`_.
 Battery Status and Virtual Sensors  1     See `Battery Status and Virtual Sensors`_.
 Network Information                 1     Unused by Probe, D/C
 Overheating Sensors                 1     See `Overheating Sensors`_.
+Thermometer Preferences             1     See `Thermometer Preferences`_.
 =================================== ===== ==========================================
 
 GATT Services and Characteristics

--- a/probe_ble_specification.rst
+++ b/probe_ble_specification.rst
@@ -618,13 +618,15 @@ Thermometer Preferences
 
 Thermometer preferences are expressed in a packed 8-bit (1-byte) field:
 
-+------+-------------------+
-| Bits | Description       |
-+======+===================+
-| 1-2  | See `Power Mode`_ |
-+------+-------------------+
-| 3-8  | Reserved          |
-+------+-------------------+
++------+---------------------------+
+| Bits | Description               |
++======+===========================+
+| 1-2  | See `Power Mode`_         |
++------+---------------------------+
+| 3    | See `High Radio Power`_   |
++------+---------------------------+
+| 4-8  | Reserved                  |
++------+---------------------------+
 
 Power Mode
 **********
@@ -640,6 +642,23 @@ Power Mode is expressed as a 2-bit enumerated field.
 ||     || * ``1``: Always On            |
 ||     || * ``2-3``: Reserved           |
 +------+--------------------------------+
+
+High Radio Power
+****************
+
+High Radio Power is expressed as a 1-bit boolean field that indicates whether the device transmits at high radio power (+8 dBm) or normal power (+0 dBm).
+
++------+--------------------------------------------------+
+| Bit  | Description                                      |
++======+==================================================+
+|| 3   || High Radio Power:                               |
+||     || * ``0``: Normal power (+0 dBm)                  |
+||     || * ``1``: High power (+8 dBm)                    |
++------+--------------------------------------------------+
+
+**Note:** Probe V1 devices transmit at normal power (+0 dBm, bit=0). Probe V2 and later transmit at high power (+8 dBm, bit=1) for improved range and connection reliability.
+
+**RSSI Adjustment:** When using RSSI for proximity detection, applications should adjust thresholds based on this bit. High power devices (+8 dBm) will show approximately 8 dB higher (less negative) RSSI values at the same physical distance compared to normal power devices.
 
 Prediction Log
 ------------------------------


### PR DESCRIPTION
Add documentation for the new high radio power bit (bit 3) in ThermometerPreferences structure for both Probe and MeatNet Node BLE specifications.

## Changes

### probe_ble_specification.rst
- Update Thermometer Preferences bit table to show bit 3 as High Radio Power
- Add High Radio Power section with detailed description
- Note Probe V1 uses +0 dBm, V2+ uses +8 dBm
- Explain RSSI adjustment needed for proximity detection

### meatnet_node_ble_specification.rst
- Update Thermometer Preferences bit table to show bit 3 as High Radio Power
- Add High Radio Power section with detailed description
- Note MeatNet Nodes use +8 dBm for improved mesh reliability
- Explain RSSI adjustment for proximity and association

## Related Issues
- PRO-132
- TIM-249
- TIM-218
- IOS-657
- DROID-740

🤖 Generated with Claude Code