### PR TITLE
Document knob voltage and angle in ENGINE_STATUS spec

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,5 @@
+# Sphinx configuration for Combustion Inc. BLE Protocol Documentation
+
+project = 'Combustion Inc. BLE Protocol Documentation'
+extensions = []
+master_doc = 'index'

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -154,8 +154,7 @@ Value                      Format   Bytes Description
 ========================== ======== ===== ==================================
 Serial Number              uint8_t  10    Engine serial number
 Control Device Type        uint8_t  1     The type of control device. See `Product Type`_.
-Probe Serial Number        uint32_t 4     Control device serial number, if device type is probe
-Node Serial Number         uint8_t  10    Control device serial number, if device type is node (gauge)
+Product Serial Number      uint8_t  10    See `Product Serial Number`_.
 ========================== ======== ===== ==================================
 
 .. note::
@@ -181,6 +180,15 @@ Sphinx link:
 
 GitHub link:
 `See Product Type <./meatnet_node_ble_specification.rst#product-type>`_
+
+Product Serial Number
+---------------------
+
+Sphinx link:
+:ref:`See Product Serial Number <meatnet_product_serial_number>`
+
+GitHub link:
+`See Product Serial Number <./meatnet_node_ble_specification.rst#product-serial-number>`_
 
 Session ID
 ----------

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -113,6 +113,8 @@ Node Serial Number                 uint8_t  10    Control device serial number, 
 Engine Status Flags                uint8_t  1     See `Engine Status Flags`_.
 Fan Status                         uint8_t  12    See `Fan Status`_.
 Network Information                uint8_t  1     See `Network Information`_.
+Knob Voltage                       uint16_t 2     See `Knob Status`_.
+Knob Angle                         uint16_t 2     See `Knob Status`_.
 ================================== ======== ===== =====================================================
 
 
@@ -301,6 +303,28 @@ Bits       Description
 33-64      Fan off time in each time window (milliseconds)
 65-96      Fan on time in each time window (milliseconds)
 ========== =============================
+
+
+Knob Status
+-----------
+
+Knob Voltage
+************
+
+The knob voltage is a 16-bit unsigned integer representing the raw potentiometer
+voltage in millivolts (0-3300 mV)::
+
+    Voltage (V) = raw value / 1000.0
+
+Knob Angle
+**********
+
+The knob angle is a 16-bit unsigned integer representing the calculated knob
+position in tenths of degrees (0-3599)::
+
+    Angle (degrees) = raw value / 10.0
+
+The angle is measured clockwise from the Off position (0 degrees).
 
 
 Engine Preferences

--- a/index.rst
+++ b/index.rst
@@ -10,3 +10,6 @@ Combustion Inc. BLE Protocol Documentation
     probe_ble_specification
     meatnet_node_ble_specification
     gauge_ble_specification
+    engine_ble_specification
+    display_ble_specification
+    booster_ble_specification

--- a/meatnet_node_ble_specification.rst
+++ b/meatnet_node_ble_specification.rst
@@ -867,6 +867,17 @@ Possible values:
 * ``5``: Booster (Charger)
 * ``6``: Engine
 
+.. _meatnet_product_serial_number:
+
+Product Serial Number
+---------------------
+
+This 10-byte field contains a representation of the product serial number. This field is
+a ``union``, which can be either a ``uint32_t`` Probe serial number (only the first 
+4 bytes are used), or a ``char[10]`` alphanumeric Node serial number. Any time this field
+is present, the appropriate `Product Type`_ must also be present so it can be decoded
+correctly.
+
 Raw Temperature Data
 --------------------
 


### PR DESCRIPTION
## Summary
- Add Knob Voltage and Knob Angle rows to the ENGINE_STATUS data table
- Add new "Knob Status" section documenting the millivolt and tenths-of-degrees encoding

## Test plan
- [ ] Verify RST renders correctly
- [ ] Verify field descriptions match firmware implementation in combustion-fw-shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)