### PR TITLE
Document Engine controller status and serial number format

### DIFF
--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -108,8 +108,7 @@ Battery Status                     uint8_t  3     See `Battery Status`_.
 Temperature Set Point              uint16_t 2     See `Temperature Point`_.
 Control Temperature                uint16_t 2     See `Temperature Point`_.
 Control Device Type                uint8_t  1     The type of control device. See `Product Type`_.
-Probe Serial Number                uint32_t 4     Control device serial number, if device type is probe
-Node Serial Number                 uint8_t  10    Control device serial number, if device type is node (gauge)
+Control Device Serial Number       uint8_t  10    See `Product Serial Number`_.
 Engine Status Flags                uint8_t  1     See `Engine Status Flags`_.
 Fan Status                         uint8_t  12    See `Fan Status`_.
 Controller Status                   uint8_t  8     See `Controller Status`_.

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -111,7 +111,7 @@ Control Device Type                uint8_t  1     The type of control device. Se
 Control Device Serial Number       uint8_t  10    See `Product Serial Number`_.
 Engine Status Flags                uint8_t  1     See `Engine Status Flags`_.
 Fan Status                         uint8_t  12    See `Fan Status`_.
-Controller Status                   uint8_t  8     See `Controller Status`_.
+Controller Status                  uint8_t  8     See `Controller Status`_.
 Network Information                uint8_t  1     See `Network Information`_.
 Knob Voltage                       uint16_t 2     See `Knob Status`_.
 Knob Angle                         uint16_t 2     See `Knob Status`_.

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -108,7 +108,7 @@ Battery Status                     uint8_t  3     See `Battery Status`_.
 Temperature Set Point              uint16_t 2     See `Temperature Point`_.
 Control Temperature                uint16_t 2     See `Temperature Point`_.
 Control Device Type                uint8_t  1     The type of control device. See `Product Type`_.
-Control Device Serial Number       uint8_t  10    See `Product Serial Number`_.
+Control Device Serial Number       uint8_t  12    See `Product Serial Number`_.
 Engine Status Flags                uint8_t  1     See `Engine Status Flags`_.
 Fan Status                         uint8_t  12    See `Fan Status`_.
 Controller Status                  uint8_t  8     See `Controller Status`_.

--- a/engine_ble_specification.rst
+++ b/engine_ble_specification.rst
@@ -104,7 +104,7 @@ Serial Number                      uint8_t  10    Engine serial number
 Session ID                         uint32_t 4     See `Session ID`_.
 Sample Period                      uint16_t 2     Number of milliseconds between samples.
 Log Range                          uint32_t 8     See `Log Range`_.
-Battery Status                     uint8_t  2     See `Battery Status`_.
+Battery Status                     uint8_t  3     See `Battery Status`_.
 Temperature Set Point              uint16_t 2     See `Temperature Point`_.
 Control Temperature                uint16_t 2     See `Temperature Point`_.
 Control Device Type                uint8_t  1     The type of control device. See `Product Type`_.
@@ -112,6 +112,7 @@ Probe Serial Number                uint32_t 4     Control device serial number, 
 Node Serial Number                 uint8_t  10    Control device serial number, if device type is node (gauge)
 Engine Status Flags                uint8_t  1     See `Engine Status Flags`_.
 Fan Status                         uint8_t  12    See `Fan Status`_.
+Controller Status                   uint8_t  8     See `Controller Status`_.
 Network Information                uint8_t  1     See `Network Information`_.
 Knob Voltage                       uint16_t 2     See `Knob Status`_.
 Knob Angle                         uint16_t 2     See `Knob Status`_.
@@ -233,7 +234,7 @@ steps of 0.1°C::
 Battery Status
 --------------
 
-The battery status is expressed in a packed 2-byte field.
+The battery status is expressed in a packed 3-byte field.
 
 +----------+----------------------------+
 | Bits     | Description                |
@@ -248,6 +249,14 @@ The battery status is expressed in a packed 2-byte field.
 ||         || * ``1``: Charging         |
 ||         || * ``2``: Fully charged    |
 +----------+----------------------------+
+|| 17-24   || Battery Voltage           |
+||         || Voltage × 10              |
+||         || Range: 0-25.5V            |
++----------+----------------------------+
+
+::
+
+    Voltage (V) = raw value / 10.0
 
 
 Engine Status Flags
@@ -288,8 +297,8 @@ Lid Open
 Fixed Speed
 ***********
 
-1 if the Engine fan is running at a fixed speed (not using PID control to a setpoint).
-0 if the fan is using normal PID temperature control.
+1 if the Engine fan is running at a fixed speed (not controlling to a setpoint).
+0 if the fan is controlling to a temperature setpoint.
 
 Fan Status
 ----------------
@@ -311,6 +320,52 @@ Bits       Description
 33-64      Fan off time in each time window (milliseconds)
 65-96      Fan on time in each time window (milliseconds)
 ========== =============================
+
+
+Controller Status
+-----------------
+
+The controller status is expressed in a packed 8-byte field.
+
+========== =============================
+Bits       Description
+========== =============================
+1-8        Controller State
+            * ``0``: Idle
+            * ``1``: Startup
+            * ``2``: Probe
+            * ``3``: Observe
+            * ``4``: Rest
+9-16       Response Coefficient
+            Learned response coefficient × 500
+            (0-255 maps to 0.000-0.510)
+17-24      Cycles Completed
+            Number of complete control cycles
+            (0-255)
+25-32      Flags (see `Controller Flags`_)
+33-48      Smoothed Temperature
+            Temperature × 10 in °C
+            (e.g., 1200 = 120.0°C)
+49-56      Time to Peak
+            Estimated time-to-peak in seconds (0-255)
+57-64      Drift Rate
+            Signed drift rate × 1000
+            (-128 to +127 maps to
+            -0.128 to +0.127 °C/s)
+========== =============================
+
+Controller Flags
+****************
+
++------+----------------------------+
+| Bit  | Description                |
++======+============================+
+| 1    | Reached Setpoint           |
++------+----------------------------+
+| 2    | Maintenance Mode           |
++------+----------------------------+
+| 3-8  | Reserved                   |
++------+----------------------------+
 
 
 Knob Status


### PR DESCRIPTION
## Summary
- Add `Controller Status` (8-byte) field to `ENGINE_STATUS` with state, response coefficient, cycles, flags, smoothed temperature, time-to-peak, and drift rate
- Expand `Battery Status` to 3 bytes to include battery voltage (voltage × 10)
- Replace separate `Probe Serial Number` / `Node Serial Number` rows with a single `Control Device Serial Number` per the unified `Product Serial Number` format
- Update `meatnet_node_ble_specification.rst` serial number sizes from 10 to 12 bytes in linking/unlinking commands and responses
- Clarify Fixed Speed flag wording (control to setpoint vs. fixed speed)

## Test plan
- [ ] Verify RST renders correctly
- [ ] Verify field sizes and encodings match firmware implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)